### PR TITLE
Hotfix: fix savegame delete when browser closed

### DIFF
--- a/codeclicker/index.html
+++ b/codeclicker/index.html
@@ -17,7 +17,7 @@
     </div>
 
     <p style="position: absolute;bottom: 0;left:0;z-index: 2000;
-    filter: drop-shadow(2px 2px 5px black) drop-shadow(-2px -2px 5px black);">Really Early Indev v1.0.1 (Emergency Patch) / REI v1.0.1 <a href="../">Back</a>/<a href="../devlog/bid3">Update Devlog</a>/<a onclick="saveGame()" href="">Save Game</a></p>
+    filter: drop-shadow(2px 2px 5px black) drop-shadow(-2px -2px 5px black);">Really Early Indev v1.0.2 Patch / REI v1.0.2 / Savegame REI1_0 <a href="../">Back</a>/<a href="../devlog/bid3">Update Devlog</a>/<a onclick="saveGame()" href="">Save Game</a></p>
 
     <div class="hoverTooltip" id="hoverTooltip">
         <div class="tooltipTop">

--- a/codeclicker/main.js
+++ b/codeclicker/main.js
@@ -274,8 +274,8 @@ function generateSavegameCode(){
     return encryptSave(saveCode);
 }
 function saveGame(){
-    document.cookie = "savegame=" + generateSavegameCode() + ";";
-    document.cookie = "saveVersion=REI1_0;";
+    document.cookie = "savegame=" + generateSavegameCode() + "; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
+    document.cookie = "saveVersion=REI1_0; expires=Fri, 31 Dec 9999 23:59:59 GMT; path=/";
     notification({
         title:"Game saved!",
         text:"Your game was saved to your cookie just now.",


### PR DESCRIPTION
Browser with bug spotted: Microsoft Edge
When you close the browser, your game will be deleted because it was seen as a session cookie instead of a permenant cookie.
Fix issue #10 